### PR TITLE
feat: add x-brand-id header mapping support

### DIFF
--- a/ezgrpc/grpc.go
+++ b/ezgrpc/grpc.go
@@ -32,6 +32,7 @@ const (
 	keyUserEmail    = "user-email"
 	keyUserName     = "user-name"
 	keyUserLanguage = "user-language"
+	keyBrandID      = "brand-id"
 )
 
 var (
@@ -48,6 +49,7 @@ var (
 		"x-user-email":    keyUserEmail,
 		"x-user-name":     keyUserName,
 		"x-user-language": keyUserLanguage,
+		"x-brand-id":      keyBrandID,
 	}
 
 	// DefaultHeaderMatcher is a grpc-gateway option that maps incoming HTTP headers to gRPC metadata.


### PR DESCRIPTION
Add support for x-brand-id header mapping in gRPC-Gateway to enable brand-based multi-tenancy in microservices. This allows the API gateway to pass brand identification through HTTP headers that get mapped to gRPC metadata.

- Add keyBrandID constant for brand-id metadata key
- Add x-brand-id to incoming header mapping in DefaultHeaderMatcher